### PR TITLE
Support full specification of the CEF format 'severity' field

### DIFF
--- a/cefevent/__init__.py
+++ b/cefevent/__init__.py
@@ -209,7 +209,10 @@ class CEFEvent(object):
 
         if prefix in self._prefix_list:
             if prefix == 'severity':
-                if int(value) in range(0, 11):
+                if value in ['Unknown', 'Low', 'Medium', 'High', 'Very-High']:
+                    self.prefixes[prefix] = value
+                    return self.prefixes[prefix]
+                elif int(value) in range(0, 11):
                     self.prefixes[prefix] = int(value)
                     return self.prefixes[prefix]
                 else:


### PR DESCRIPTION
According to the CEF format specification the 'severity' field should also support the strings: 'Unknown', 'Low', 'Medium', 'High' and 'Very-High'

Quote:

> Severity is  a   string or integer and reflects the importance of the event. The valid string values are Unknown, Low, Medium, High, and Very-High. The valid integer values are 0-3=Low, 4-6=Medium, 7- 8=High, and 9-10=Very-High.

https://community.microfocus.com/t5/ArcSight-Connectors/ArcSight-Common-Event-Format-CEF-Implementation-Standard/ta-p/1645557